### PR TITLE
Feat/support version flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.23'
-          
       - name: Semantic Release
         id: semantic
         uses: cycjimmy/semantic-release-action@v4

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,13 @@ builds:
     goarch:
       - arm64
       - amd64
+    main: ./cmd
+    binary: grafana-autodoc
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
 
 archives:
   - format: tar.gz
@@ -50,7 +57,7 @@ brews:
     install: |
       bin.install "grafana-autodoc"
     test: |
-      system "#{bin}/grafana-autodoc --help"
+      system "#{bin}/grafana-autodoc --version"
     repository:
       owner: rastogiji
       name: homebrew-tap

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 BIN_FILE := cmd/bin/autodoc
 GO_PATH=$(shell go env GOPATH)
+
+# Get git information for version injection
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Build flags with version information
+LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+
 .PHONY: build
 build:
-	go build -o ${BIN_FILE}  cmd/main.go
-
+	go build -ldflags "$(LDFLAGS)" -o ${BIN_FILE} cmd/main.go
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Grafana Autodoc
 [![Coverage Status](https://coveralls.io/repos/github/rastogiji/grafana-autodoc/badge.svg?branch=main)](https://coveralls.io/github/rastogiji/grafana-autodoc?branch=main)
+
 This tool generates documentation for Grafana Dashboards from their json representation. Even though you can use this tool as a standalone binary or as a kubectl plugin, it is intended to be used a Github Action to generate documentation for your Grafana Dashboards as code.
 
 ## Example Usage

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,11 @@ import (
 )
 
 var (
+	// Version information - set during build time via ldflags
+	version = "dev"     // Default to "dev" for development builds
+	commit  = "unknown" // Git commit hash
+	date    = "unknown" // Build date
+
 	// input specifies the path to dashboard file, directory, or glob pattern
 	input string
 	// output specifies the path to output directory where markdown files will be generated
@@ -28,6 +33,8 @@ var (
 	logLevel int
 	// help indicates whether to show the help message
 	help bool
+	// showVersion indicates whether to show version information
+	showVersion bool
 	// setupLog is the initial logger used for setup and validation phases
 	setupLog = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	// out is the output writer, configurable for testing
@@ -63,11 +70,18 @@ func (r *runner) run() error {
 	cli.StringVar(&output, "output", ".", "Path to output directory where markdown files will be generated (default: current directory)")
 	cli.IntVar(&logLevel, "log-level", 0, "Debug: -4, Info: 0, Warn: 4, Error: 8 (default: Info)")
 	cli.BoolVar(&help, "help", false, "Show help message")
+	cli.BoolVar(&showVersion, "version", false, "Show version information")
 
 	cli.Parse(os.Args[1:])
 
 	if help {
-		flag.Usage()
+		fmt.Fprintf(out, "Usage of %s:\n", os.Args[0])
+		cli.PrintDefaults()
+		return nil
+	}
+
+	if showVersion {
+		printVersion()
 		return nil
 	}
 
@@ -87,6 +101,18 @@ func (r *runner) run() error {
 
 	slog.Info("beginning processing files")
 	return r.fileProcessor()
+}
+
+// printVersion outputs version information to stdout in a formatted manner.
+// It displays the version, commit hash, and build date if available.
+func printVersion() {
+	fmt.Fprintf(out, "grafana-autodoc %s\n", version)
+	if commit != "unknown" {
+		fmt.Fprintf(out, "commit: %s\n", commit)
+	}
+	if date != "unknown" {
+		fmt.Fprintf(out, "built: %s\n", date)
+	}
 }
 
 // processFiles handles the actual file processing logic based on the input type.


### PR DESCRIPTION
This PR does the following:
1. Add support for the version flag with injected dependencies
2. Fix Dockerfile to use make and use a custom user instead of root user
3. Remove unnecessary code